### PR TITLE
Cache only default profile directory on build

### DIFF
--- a/.github/workflows/erlang-parallel-build.yml
+++ b/.github/workflows/erlang-parallel-build.yml
@@ -93,9 +93,7 @@ jobs:
             ${{ inputs.cache-version }}-${{ runner.os }}-otp-${{ inputs.otp-version }}-build-
 
       - name: Compile
-        run: |
-          rebar3 compile
-          rebar3 as test compile
+        run: rebar3 compile
 
   check:
     name: Check

--- a/.github/workflows/erlang-parallel-build.yml
+++ b/.github/workflows/erlang-parallel-build.yml
@@ -85,9 +85,9 @@ jobs:
           generator-version: ${{ inputs.erlang-generator-version }}
 
       - name: Cache _build
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
-          path: _build/*/lib
+          path: _build/default/lib
           key: ${{ inputs.cache-version }}-${{ runner.os }}-otp-${{ inputs.otp-version }}-build-${{ hashFiles('rebar.lock') }}
           restore-keys: |
             ${{ inputs.cache-version }}-${{ runner.os }}-otp-${{ inputs.otp-version }}-build-
@@ -125,9 +125,9 @@ jobs:
           generator-version: ${{ inputs.erlang-generator-version }}
 
       - name: Cache _build
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
-          path: _build/*/lib
+          path: _build/default/lib
           key: ${{ inputs.cache-version }}-${{ runner.os }}-otp-${{ inputs.otp-version }}-build-${{ hashFiles('rebar.lock') }}
           restore-keys: |
             ${{ inputs.cache-version }}-${{ runner.os }}-otp-${{ inputs.otp-version }}-build-
@@ -169,15 +169,15 @@ jobs:
           generator-version: ${{ inputs.erlang-generator-version }}
 
       - name: Cache _build
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
-          path: _build/*/lib
+          path: _build/default/lib
           key: ${{ inputs.cache-version }}-${{ runner.os }}-otp-${{ inputs.otp-version }}-build-${{ hashFiles('rebar.lock') }}
           restore-keys: |
             ${{ inputs.cache-version }}-${{ runner.os }}-otp-${{ inputs.otp-version }}-build-
 
       - name: Cache PLTs
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: _build/test/rebar3_*_plt
           key: ${{ inputs.cache-version }}-${{ runner.os }}-otp-${{ inputs.otp-version }}-plt-${{ hashFiles('rebar.lock') }}
@@ -215,9 +215,9 @@ jobs:
           generator-version: ${{ inputs.erlang-generator-version }}
 
       - name: Cache _build
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
-          path: _build/*/lib
+          path: _build/default/lib
           key: ${{ inputs.cache-version }}-${{ runner.os }}-otp-${{ inputs.otp-version }}-build-${{ hashFiles('rebar.lock') }}
           restore-keys: |
             ${{ inputs.cache-version }}-${{ runner.os }}-otp-${{ inputs.otp-version }}-build-


### PR DESCRIPTION
Turns out rebar3 skips updating test-only dependencies even if their refs changed in `rebar.config`.